### PR TITLE
Export newpipe subscriptions

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -95,7 +95,6 @@ def follow_channel():
     return redirect(url_for('channel', channel_id = channel_id))
 
 
-# exports the list of subscriptions in a format newpipe can import
 @app.route('/export_newpipe_subscription')
 def export_newpipe_subscription():
     followed_channels = [{'info': handler.get_channel_info(x), 'youtube_id': x} for x in handler.get_followed()]

--- a/app/routes.py
+++ b/app/routes.py
@@ -95,6 +95,7 @@ def follow_channel():
     return redirect(url_for('channel', channel_id = channel_id))
 
 
+# exports the list of subscriptions in a format newpipe can import
 @app.route('/export_newpipe_subscription')
 def export_newpipe_subscription():
     followed_channels = [{'info': handler.get_channel_info(x), 'youtube_id': x} for x in handler.get_followed()]

--- a/app/templates/embed.html
+++ b/app/templates/embed.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html style="height: 100%;">
     <head>
     </head>
-    <body>
-        <video width="100%" height="100%" controls>
+    <body style="background-color: #000; height: 100%; margin: 0;">
+        <video width="100%" height="100%" style="display: block; margin: auto;" poster="https://i4.ytimg.com/vi/{{ video['video_id'] }}/hqdefault.jpg"  controls>
             <source src="{{ video['video_url'] }}">
         </video>
     </body>

--- a/app/templates/newpipe_subscription.json
+++ b/app/templates/newpipe_subscription.json
@@ -1,0 +1,16 @@
+{
+    "app_version": "0.21.16",
+    "app_version_int": 982,
+    "subscriptions": [
+        {% for channel in followed_channels %}
+        {
+            "service_id": 0,
+            "url": "https://www.youtube.com/channel/{{ channel['youtube_id'] }}",
+            "name": "{{ channel['info']['title'] }}"
+        }
+        {% if not loop.last %}
+        ,
+        {% endif %}
+        {% endfor %}
+    ]
+}

--- a/app/templates/watch.html
+++ b/app/templates/watch.html
@@ -4,7 +4,7 @@
 {% endblock %}
 {% block content %}
     <video id="video" width="100%" controls>
-        <source src="{{ video_info['video_url'] }}">
+	    <source src="{{ video_info['video_url'] }}" type="video/mp4">
     </video>
     <h1 id="title">{{ video_info['title'] }}</h1>
     <a id="channel_link" href="/channel/{{ video_info['channel_id'] }}">{{ video_info['channel_title'] }}</a>


### PR DESCRIPTION
Last commit, forgot to add more templates

# app/templates/embed.html
Now embedding videos in other pages will appear like youtube's embeds, except no javascript is used so there won't be any of the fancy options usually available to embedding.

# app/templates/newpipe_subscription.json
offloads generating the json file to a jinja2 template. If Newpipe makes any changes to how their subscription export format works, all that needs to be updated is this file.

# app/templates/watch.html
I have no idea if this will have any effect, it specifies it as an mp4 video by default